### PR TITLE
Support for automated trusted publishing

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+github: halostatue
+buy_me_a_coffee: halostatue
+ko_fi: halostatue
+tidelift: rubygems/minitar

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: bundler
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/publish-gem.yml
+++ b/.github/workflows/publish-gem.yml
@@ -1,0 +1,58 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - lib/hoe/halostatue/version.rb
+
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+    paths:
+      - lib/hoe/halostatue/version.rb
+
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  release:
+    if: github.repository == 'halostatue/hoe-halostatue' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged))
+
+    runs-on: ubuntu-latest
+    environment: production
+
+    env:
+      rubygems_release_gem: true
+
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        with:
+          persist-credentials: true
+
+      - id: rubygems
+        run: |
+          ruby -e 'print "version=", Gem::Specification.load(ARGV[0]).rubygems_version, "\n"' hoe-halostatue.gemspec >> "$GITHUB_OUTPUT"
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@d781c1b4ed31764801bfae177617bb0446f5ef8d #v1.218.0
+        with:
+          bundler-cache: false
+          ruby-version: ruby
+
+      - name: Install dependencies
+        run: |
+          gem update --system="${RUBYGEMS_VERSION}"
+          bundle install --jobs 4 --retry 3
+        env:
+          RUBYGEMS_VERSION: ${{ steps.rubygems.outputs.version }}
+
+      - uses: rubygems/release-gem@a25424ba2ba8b387abc8ef40807c2c85b96cbe32 # v1.1.1

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,175 @@
+name: Ruby CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # v1.207.0
+        with:
+          ruby-version: '3.3'
+          rubygems: latest
+          bundler: 2
+          bundler-cache: true
+
+      - run: bundle exec standardrb
+
+  # required-ubuntu:
+  #   name: Ruby ${{ matrix.ruby }} - ${{ matrix.os }}
+  #
+  #   permissions:
+  #     contents: read
+  #
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os:
+  #         - ubuntu-20.04
+  #         - ubuntu-22.04
+  #         - ubuntu-24.04
+  #       ruby:
+  #         - '3.1'
+  #         - '3.2'
+  #         - '3.3'
+  #         - '3.4'
+  #         - truffleruby
+  #
+  #   runs-on: ${{ matrix.os }}
+  #
+  #   steps:
+  #     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  #       with:
+  #         persist-credentials: false
+  #
+  #     - uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # v1.207.0
+  #       with:
+  #         ruby-version: ${{ matrix.ruby }}
+  #         rubygems: latest
+  #         bundler: 2
+  #         bundler-cache: true
+  #
+  #     - run: bundle exec ruby -S rake test --trace
+
+  # required-macos:
+  #   name: Ruby ${{ matrix.ruby }} - ${{ matrix.os }}
+  #
+  #   permissions:
+  #     contents: read
+  #
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os:
+  #         - macos-13
+  #         - macos-14
+  #         - macos-15
+  #       ruby:
+  #         - '3.1'
+  #         - '3.2'
+  #         - '3.3'
+  #         - '3.4'
+  #
+  #   runs-on: ${{ matrix.os }}
+  #
+  #   steps:
+  #     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  #       with:
+  #         persist-credentials: false
+  #
+  #     - uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # v1.207.0
+  #       with:
+  #         ruby-version: ${{ matrix.ruby }}
+  #         rubygems: latest
+  #         bundler: 2
+  #         bundler-cache: true
+  #
+  #     - run: bundle exec ruby -S rake test --trace
+
+  # required-windows:
+  #   name: Ruby ${{ matrix.ruby }} - ${{ matrix.os }}
+  #
+  #   permissions:
+  #     contents: read
+  #
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os:
+  #         - windows-2019
+  #         - windows-2022
+  #       ruby:
+  #         - '3.1'
+  #         - '3.2'
+  #         - '3.3'
+  #         # - '3.4' # Not yet present
+  #         - mswin
+  #         - ucrt
+  #       include:
+  #         - ruby: mingw
+  #           os: windows-2022
+  #
+  #   runs-on: ${{ matrix.os }}
+  #
+  #   steps:
+  #     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  #       with:
+  #         persist-credentials: false
+  #
+  #     - uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # v1.207.0
+  #       with:
+  #         ruby-version: ${{ matrix.ruby }}
+  #         rubygems: latest
+  #         bundler: 2
+  #         bundler-cache: true
+  #
+  #     - run: bundle exec ruby -S rake test --trace
+
+  # ruby-head-optional:
+  #   name: Ruby ${{ matrix.ruby }} - ${{ matrix.os }} (optional)
+  #
+  #   permissions:
+  #     contents: read
+  #
+  #   strategy:
+  #     fail-fast: false
+  #
+  #     matrix:
+  #       ruby:
+  #         - head
+  #       os:
+  #         - macos-latest
+  #         - ubuntu-latest
+  #         - windows-latest
+  #
+  #   continue-on-error: true
+  #   runs-on: ${{ matrix.os }}
+  #
+  #   steps:
+  #     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  #       with:
+  #         persist-credentials: false
+  #
+  #     - uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # v1.207.0
+  #       with:
+  #         ruby-version: ${{ matrix.ruby }}
+  #         rubygems: latest
+  #         bundler: 2
+  #         bundler-cache: true
+  #
+  #     - run: bundle exec ruby -S rake test --trace

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,35 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: zizmor latest via Cargo
+    runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+      # required for workflows in private repositories
+      contents: read
+      actions: read
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 # v1.10.1
+
+      - run: cargo install --locked zizmor
+      - run: zizmor --persona pedantic --format sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: github/codeql-action/upload-sarif@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0 #v3.28.9
+        with:
+          sarif_file: results.sarif
+          category: zizmor

--- a/.hoerc
+++ b/.hoerc
@@ -34,7 +34,8 @@ exclude: !ruby/regexp '/
     | svn
     | vagrant
   )\/
-  | [gG]emfile(?:\.lock)?
+  | [gG]emfile(?:\.lock)?$
+  | [Aa]ppraisals$
   | (?i:TAGS)$
   | Vagrantfile$
 /x'

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,0 +1,7 @@
+---
+parallel: true
+ruby_version: 3.1
+
+ignore:
+  - '*.gemspec'
+  - pkg/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # hoe-halostatue Changelog
 
+## 2.0.0 / 2025-02-19
+
+- Directly incorporate the functionality of `hoe-doofus` and `hoe-git2` into
+  `hoe-halostatue` and make it possible to disable features that would block
+  automated releases via [rubygems/release-gem][trusted].
+
+- Minor improvements to `Hoe#parse_urls` for Markdown READMEs so that wrapped
+  URLs work.
+
+- Added a `trusted_release` mode that skips the need for a `VERSION` specifier
+  on the release task and ensures that features which impede automated releases
+  are disabled.
+
+- Enabled trusted publishing for this repo.
+
 ## 1.0.1 / 2024-12-31
 
 - Birthday!
+
+[trusted]: https://github.com/rubygems/release-gem

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at [INSERT CONTACT
+METHOD]. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq>. Translations are available at
+<https://www.contributor-covenant.org/translations>.
+
+[homepage]: https://www.contributor-covenant.org
+[Mozilla CoC]: https://github.com/mozilla/diversity

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing
+
+I value any contribution to Hoe::Halostatue you can provide: a bug report, a
+feature request, or code contributions. There are a few guidelines for
+contributing to Hoe::Halostatue:
+
+- Match my coding style.
+- Use a thoughtfully-named topic branch that contains your change. Rebase your
+  commits into logical chunks as necessary.
+- Use [quality commit messages][quality commit messages].
+- Do not change the version number; when your patch is accepted and a release is
+  made, the version will be updated at that point.
+- Submit a GitHub pull request with your changes.
+- New or changed behaviours require appropriate documentation.
+
+Hoe::Halostatue uses Ryan Davis's [Hoe][Hoe] to manage the release process, and
+it adds a number of rake tasks.
+
+## Workflow
+
+Here's the most direct way to get your work merged into the project:
+
+- Fork the project.
+- Clone your fork (`git clone git://github.com/<username>/hoe-halostatue.git`).
+- Create a topic branch to contain your change
+  (`git checkout -b my_awesome_feature`).
+- Hack away, add tests. Not necessarily in that order.
+- Make sure everything still passes by running `rake`.
+- If necessary, rebase your commits into logical chunks, without errors.
+- Push the branch up (`git push origin my_awesome_feature`).
+- Create a pull request against halostatue/hoe-halostatue and describe what your
+  change does and the why you think it should be merged.
+
+[quality commit messages]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+[hoe]: https://github.com/seattlerb/hoe

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,20 @@
+# Contributors
+
+- Austin Ziegler created Hoe::Halostatue.
+
+It would not be possible without Ryan Davis's [Hoe][hoe] and depends on the work
+of others in the Ruby community:
+
+- James Tucker (@raggi) for [`hoe-gemspec2`][hoe-gemspec2]
+- James Barnette (@jbarnette) for [`hoe-doofus`][hoe-doofus],
+  [`hoe-git2`][hoe-git2], and [`hoe-rubygems`][hoe-rubygems]
+- Mike Dalessio (@flavorjones) for [`hoe-markdown`][hoe-markdown]
+- Samuel Giddins (@segiddins) for providing the inspiration to make all of this
+  work better for trusted publishing for RubyGems.
+
+[hoe]: https://github.com/seattlerb/hoe
+[hoe-doofus]: https://github.com/jbarnette/hoe-doofus
+[hoe-gemspec2]: https://github.com/raggi/hoe-gemspec2
+[hoe-git2]: https://github.com/halostatue/hoe-git2
+[hoe-markdown]: https://github.com/flavorjones/hoe-markdown
+[hoe-rubygems]: https://github.com/jbarnette/hoe-rubygems

--- a/LICENCE.md
+++ b/LICENCE.md
@@ -1,0 +1,24 @@
+## Licence
+
+Hoe::Halostatue is free software available under the MIT licence.
+
+Copyright 2022-2025 Austin Ziegler (halostatue@gmail.com)
+
+Portions copyright 2009 John Barnette
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the 'Software'), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Manifest.txt
+++ b/Manifest.txt
@@ -1,5 +1,10 @@
 CHANGELOG.md
+CODE_OF_CONDUCT.md
+CONTRIBUTING.md
+CONTRIBUTORS.md
+LICENCE.md
 Manifest.txt
 README.md
 Rakefile
+SECURITY.md
 lib/hoe/halostatue.rb

--- a/Rakefile
+++ b/Rakefile
@@ -9,14 +9,18 @@ Hoe.plugin :halostatue
 Hoe.spec "hoe-halostatue" do
   developer "Austin Ziegler", "halostatue@gmail.com"
 
+  self.trusted_release = ENV["rubygems_release_gem"] == "true"
+
   self.extra_rdoc_files = FileList["*.rdoc"]
 
   license "MIT"
 
+  spec_extras[:metadata] = ->(val) {
+    val.merge!({"rubygems_mfa_required" => "true"})
+  }
+
   extra_deps << ["hoe", ">= 3.0", "< 5"]
-  extra_deps << ["hoe-doofus", "~> 1.0"]
   extra_deps << ["hoe-gemspec2", "~> 1.1"]
-  extra_deps << ["hoe-git2", "~> 1.8"]
   extra_deps << ["hoe-markdown", "~> 1.6"]
   extra_deps << ["hoe-rubygems", "~> 1.0"]
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Hoe::Halostatue Security Policy
+
+## Supported Versions
+
+Security reports are accepted only for the most recent minor release.
+
+## Reporting a Vulnerability
+
+Alternatively, Send an email to [hoe-halostatue@halostatue.ca][email] with the
+text `hoe-halostatue` in the subject. Emails sent to this address should be
+encrypted using [age][age] with the following public key:
+
+```
+age1fc6ngxmn02m62fej5cl30lrvwmxn4k3q2atqu53aatekmnqfwumqj4g93w
+```
+
+[email]: mailto:hoe-halostatue@halostatue.ca
+[age]: https://github.com/FiloSottile/age
+[CVE-2017-17405]: https://nvd.nist.gov/vuln/detail/CVE-2017-17405
+[openuri]: https://sakurity.com/blog/2015/02/28/openuri.html

--- a/hoe-halostatue.gemspec
+++ b/hoe-halostatue.gemspec
@@ -1,29 +1,29 @@
 # -*- encoding: utf-8 -*-
-# stub: hoe-halostatue 1.0.1 ruby lib
+# stub: hoe-halostatue 2.0.0 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "hoe-halostatue".freeze
-  s.version = "1.0.1".freeze
+  s.version = "2.0.0".freeze
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
+  s.metadata = { "bug_tracker_uri" => "https://github.com/halostatue/halostatue-data/issues", "changelog_uri" => "https://github.com/halostatue/halostatue-data/blob/main/CHANGELOG.md", "homepage_uri" => "https://github.com/halostatue/halostatue-data/", "rubygems_mfa_required" => "true", "source_code_uri" => "https://github.com/halostatue/halostatue-data/" } if s.respond_to? :metadata=
   s.require_paths = ["lib".freeze]
   s.authors = ["Austin Ziegler".freeze]
-  s.date = "2024-12-31"
-  s.description = "Hoe::Halostatue is a [Hoe][hoe] meta-plugin that ensures that the following\nplugins are installed and enabled for your project:\n\n- [`hoe-doofus`][hoe-doofus]\n- [`hoe-gemspec2`][hoe-gemspec2]\n- [`hoe-git2`][hoe-git2]\n- [`hoe-markdown`][hoe-markdown]\n- [`hoe-rubygems`][hoe-rubygems]\n\nIt also provides an improved implementation for `Hoe#parse_urls` that works\nbetter with a Markdown README. It allows either `*` or `-` as list leaders for\nthe README. It also allows the URLs to be blank. Double colons are still\nrequired for pattern matching.\n\nIn addition to the four letter aliases in `Hoe::URLS_TO_META_MAP` (`bugs`,\n`clog`, `doco`, `docs`, `home`, `code`, `wiki`, and `mail`), this adds:\n\n- `changelog`, `changes`, and `history` as aliases for `changelog_uri`\n- `documentation` for `documentation_uri`\n- `issues` and `tickets` for `bug_tracker_uri`".freeze
+  s.date = "2025-02-19"
+  s.description = "Hoe::Halostatue is a Hoe meta-plugin that provides improved support for\nMarkdown README files, provides features from other plugins, and enables\nimproved support for trusted publishing.".freeze
   s.email = ["halostatue@gmail.com".freeze]
-  s.extra_rdoc_files = ["CHANGELOG.md".freeze, "Manifest.txt".freeze, "README.md".freeze]
-  s.files = ["CHANGELOG.md".freeze, "Manifest.txt".freeze, "README.md".freeze, "Rakefile".freeze, "lib/hoe/halostatue.rb".freeze]
+  s.extra_rdoc_files = ["CHANGELOG.md".freeze, "CODE_OF_CONDUCT.md".freeze, "CONTRIBUTING.md".freeze, "CONTRIBUTORS.md".freeze, "LICENCE.md".freeze, "Manifest.txt".freeze, "README.md".freeze, "SECURITY.md".freeze]
+  s.files = ["CHANGELOG.md".freeze, "CODE_OF_CONDUCT.md".freeze, "CONTRIBUTING.md".freeze, "CONTRIBUTORS.md".freeze, "LICENCE.md".freeze, "Manifest.txt".freeze, "README.md".freeze, "Rakefile".freeze, "SECURITY.md".freeze, "lib/hoe/halostatue.rb".freeze]
+  s.homepage = "https://github.com/halostatue/halostatue-data/".freeze
   s.licenses = ["MIT".freeze]
   s.rdoc_options = ["--main".freeze, "README.md".freeze]
-  s.rubygems_version = "3.5.23".freeze
-  s.summary = "Hoe::Halostatue is a [Hoe][hoe] meta-plugin that ensures that the following plugins are installed and enabled for your project:  - [`hoe-doofus`][hoe-doofus] - [`hoe-gemspec2`][hoe-gemspec2] - [`hoe-git2`][hoe-git2] - [`hoe-markdown`][hoe-markdown] - [`hoe-rubygems`][hoe-rubygems]  It also provides an improved implementation for `Hoe#parse_urls` that works better with a Markdown README".freeze
+  s.rubygems_version = "3.5.22".freeze
+  s.summary = "Hoe::Halostatue is a Hoe meta-plugin that provides improved support for Markdown README files, provides features from other plugins, and enables improved support for trusted publishing.".freeze
 
   s.specification_version = 4
 
   s.add_runtime_dependency(%q<hoe>.freeze, [">= 3.0".freeze, "< 5".freeze])
-  s.add_runtime_dependency(%q<hoe-doofus>.freeze, ["~> 1.0".freeze])
   s.add_runtime_dependency(%q<hoe-gemspec2>.freeze, ["~> 1.1".freeze])
-  s.add_runtime_dependency(%q<hoe-git2>.freeze, ["~> 1.8".freeze])
   s.add_runtime_dependency(%q<hoe-markdown>.freeze, ["~> 1.6".freeze])
   s.add_runtime_dependency(%q<hoe-rubygems>.freeze, ["~> 1.0".freeze])
   s.add_development_dependency(%q<standard>.freeze, ["~> 1.0".freeze])

--- a/lib/hoe/halostatue.rb
+++ b/lib/hoe/halostatue.rb
@@ -1,64 +1,223 @@
 # frozen_string_literal: true
 
-Hoe.plugin :doofus
+require "shellwords"
+require_relative "halostatue/version"
+
 Hoe.plugin :gemspec2
-Hoe.plugin :git2
 Hoe.plugin :markdown
 Hoe.plugin :rubygems
 
-# Hoe::Halostatue is a Hoe meta-plugin that ensures that the following
-# plugins are installed and enabled for your project:
+# This module is a Hoe plugin. You can set its options in your Rakefile Hoe spec, like
+# this:
 #
-# - hoe-doofus (release checklist)
-# - hoe-gemspec2 (gemspec generation)
-# - hoe-git2 (git manifest and tag generation)
-# - hoe-markdown (default to Markdown files and auto-linkification)
+#    Hoe.plugin :git
 #
-# It also provides an improved implementation for Hoe#parse_urls that
-# works better with a Markdown README. It allows either +*+ or +-+ as
-# list leaders for the README. It also allows the URLs to be blank.
-# Double colons are still required for pattern matching.
+#    Hoe.spec "myproj" do
+#      self.checklist = nil if ENV["rubygems_release_gem"] == "true"
+#      self.git_release_tag_prefix = "REL_"
+#      self.git_remotes << "myremote"
+#    end
 #
-# In addition to the four letter aliases in Hoe::URLS_TO_META_MAP
-# (+bugs+, +clog+, +doco+, +docs+, +home+, +code+, +wiki+, and +mail+),
-# this adds:
+# === Tasks
 #
-# - +changelog+, +changes+, and +history+ as aliases for +changelog_uri+
-# - +documentation+ for +documentation_uri+
-# - +issues+ and +tickets+ for +bug_tracker_uri+
-
+# git:changelog:: Print the current changelog.
+# git:manifest::  Update the manifest with Git's file list.
+# git:tag::       Create and push a tag.
+#
+# === Options
+#
+# - +checklist+: An array of reminder questions that should be asked before a release, in
+#   the form, "Did you... [question]?" You can see the defaults by running <tt>rake
+#   checklist</tt>. If the checklist is +nil+ or empty, the checklist will not shown
+#   during release. This is originally from hoe-doofus and called +doofus_checklist+.
+#
+# - +git_release_tag_prefix+: What do you want at the front of your release tags? The
+#   default is <tt>"v"</tt>.
+#
+# - +git_remotes+: Which remotes do you want to push tags, etc. to? The default is
+#   <tt>%w[origin]</tt>
+#
+# - +git_tag_enabled+: Whether a git tag should be created on release. The default is
+#   +true+.
 module Hoe::Halostatue
-  VERSION = "1.0.1"
+  # Indicates that this release is being run as part of a trusted release workflow.
+  # [default: +false+]
+  attr_accessor :trusted_release
+
+  # An array of reminder questions that should be asked before a release, in the form,
+  # "Did you... [question]?" You can see the defaults by running <tt>rake checklist</tt>.
+  #
+  # If the checklist is +nil+ or empty, the checklist will not shown during release.
+  attr_accessor :checklist
+
+  # What do you want at the front of your release tags?
+  # [default: <tt>"v"</tt>]
+  attr_accessor :git_release_tag_prefix
+
+  # Which remotes do you want to push tags, etc. to?
+  # [default: <tt>%w[origin]</tt>]
+  attr_accessor :git_remotes
+
+  # Should git tags be created on release? [default: +true+]
+  attr_accessor :git_tag_enabled
 
   def initialize_halostatue # :nodoc:
-    Hoe::URLS_TO_META_MAP.update Hoe::Halostatue::ParseUrls::URLS_TO_META_MAP
-
+    Hoe::URLS_TO_META_MAP.update({
+      "bugs" => "bug_tracker_uri",
+      "changelog" => "changelog_uri",
+      "changes" => "changelog_uri",
+      "clog" => "changelog_uri",
+      "code" => "source_code_uri",
+      "doco" => "documentation_uri",
+      "docs" => "documentation_uri",
+      "documentation" => "documentation_uri",
+      "history" => "changelog_uri",
+      "home" => "homepage_uri",
+      "issues" => "bug_tracker_uri",
+      "mail" => "mailing_list_uri",
+      "tickets" => "bug_tracker_uri",
+      "wiki" => "wiki_uri"
+    })
     Hoe.prepend Hoe::Halostatue::ParseUrls
+
+    self.checklist = [
+      "bump the version",
+      "check everything in",
+      "review the manifest",
+      "update the README and RDocs",
+      "update the changelog",
+      "regenerate the gemspec"
+    ]
+
+    self.git_release_tag_prefix = "v"
+    self.git_remotes = %w[origin]
+    self.git_tag_enabled = true
+    self.trusted_release = false
   end
 
   def define_halostatue_tasks # :nodoc:
+    desc "Show a reminder for steps I frequently forget"
+    task :checklist do
+      if checklist.nil? || checklist.empty?
+        puts "Checklist is empty."
+      else
+        puts "\n### HEY! Did you...\n\n"
+
+        checklist.each do |question|
+          question = question[0..0].upcase + question[1..]
+          question = "#{question}?" unless question.end_with?("?")
+          puts "  * #{question}"
+        end
+
+        puts
+      end
+    end
+
+    task :release_sanity do
+      unless checklist.nil? || checklist.empty? || trusted_release
+        Rake::Task[:checklist].invoke
+        puts "Hit return if you're sure, Ctrl-C if you forgot something."
+        $stdin.gets
+      end
+    end
+
+    task :spec_clean_markdown_text do
+      spec.description =
+        spec.description.gsub(/\[([^\]]+)\]\([^)]+\)/, '\1')
+          .gsub(/\[([^\]]+)\]\[[^\]]+\]/, '\1')
+
+      spec.summary =
+        spec.summary.gsub(/\[([^\]]+)\]\([^)]+\)/, '\1')
+          .gsub(/\[([^\]]+)\]\[[^\]]+\]/, '\1')
+    end
+
+    task "#{spec.name}.gemspec" => :spec_clean_markdown_text
+
+    if trusted_release
+      task :trusted_release do
+        vm = %r{^(?<version>\d+(?:\.\d+)+)(?:\.(?<pre>[a-z]\w+(?:\.\d+)+))?}
+          .match(spec.version.to_s)
+
+        ENV["VERSION"] = vm[:version]
+        ENV["PRERELEASE"] = vm[:pre]
+      end
+
+      task release_sanity: :trusted_release
+    end
+
+    return unless __run_git("rev-parse", "--is-inside-work-tree") == "true"
+
+    desc "Update the manifest with Git's file list. Use Hoe's excludes."
+    task "git:manifest" do
+      with_config do |config, _|
+        files = __run_git("ls-files").split($/)
+        files.reject! { |f| f =~ config["exclude"] }
+
+        File.open "Manifest.txt", "w" do |f|
+          f.puts files.sort.join("\n")
+        end
+      end
+    end
+
+    desc "Create and push a TAG (default #{git_release_tag_prefix}#{version})."
+    task "git:tag" do
+      if git_tag_enabled
+        tag = ENV["TAG"]
+        ver = ENV["VERSION"] || version
+        pre = ENV["PRERELEASE"] || ENV["PRE"]
+        ver += ".#{pre}" if pre
+        tag ||= "#{git_release_tag_prefix}#{ver}"
+
+        git_tag_and_push tag
+      end
+    end
+
+    task :release_sanity do
+      unless __run_git("status", "--porcelain").empty?
+        abort "Won't release: Dirty index or untracked files present!"
+      end
+    end
+
+    task release_to: "git:tag"
   end
 
-  module ParseUrls
-    URLS_TO_META_MAP = {
-      "changelog" => "changelog_uri",
-      "changes" => "changelog_uri",
-      "documentation" => "documentation_uri",
-      "history" => "changelog_uri",
-      "issues" => "bug_tracker_uri",
-      "tickets" => "bug_tracker_uri"
-    }
+  def __git(command, *params)
+    "git #{command.shellescape} #{params.compact.shelljoin}"
+  end
 
+  def __run_git(command, *params)
+    `#{__git(command, *params)}`.strip.chomp
+  end
+
+  def git_svn?
+    File.exist?(File.join(__run_git("rev-parse", "--show-toplevel"), ".git/svn"))
+  end
+
+  def git_tag_and_push tag
+    msg = "Tagging #{tag}."
+
+    if git_svn?
+      sh __git("svn", "tag", tag, "-m", msg)
+    else
+      flags =
+        if __run_git("config", "--get", "user.signingkey").empty?
+          nil
+        else
+          "-s"
+        end
+
+      sh __git("tag", flags, "-f", tag, "-m", msg)
+      git_remotes.each { |remote| sh __git("push", "-f", remote, "tag", tag) }
+    end
+  end
+
+  # This replaces Hoe#parse_urls with something that works better for Markdown.
+  module ParseUrls # :nodoc:
     def parse_urls text
-      lines = text.gsub(/^[-*] /, "").delete("<>").split("\n").grep(/\S+/)
+      keys = Hoe::URLS_TO_META_MAP.keys.join("|")
+      pattern = %r{^[-+*]\s+(#{keys})\s+::\s+[<]?(\w+://[^>\s]+)[>]?}m
 
-      return {} if lines.empty?
-
-      if /::/.match?(lines.first)
-        Hash[lines.map { |line| line.split(/\s*::\s*/) }]
-      else
-        {}
-      end
+      text.scan(pattern).to_h
     end
   end
 end

--- a/lib/hoe/halostatue/version.rb
+++ b/lib/hoe/halostatue/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Hoe::Halostatue
+  VERSION = "2.0.0"
+end


### PR DESCRIPTION
- Directly incorporate the functionality of `hoe-doofus` and `hoe-git2`
  into `hoe-halostatue` and make it possible to disable features that
  would block automated releases via rubygems/release-gem.

- Minor improvements to `Hoe#parse_urls` for Markdown READMEs so that
  wrapped URLs work.
