### PR TITLE
feat: Strict warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # hoe-halostatue Changelog
 
+## 2.1.0 / 2025-06-18
+
+- Add support for enabling "strict warnings" similar to
+  [RailsStrictWarnings][rsw].
+
+- Updated several governance documents.
+
+- Improved summary and link description cleaning.
+
 ## 2.0.1 / 2025-06-12
 
 - Update minimum version of hoe-gemspec2.
@@ -23,4 +32,5 @@
 
 - Birthday!
 
+[rsw]: https://github.com/rails/rails/blob/66732971111a62e5940268e1daf7d413c72a234f/tools/strict_warnings.rb
 [trusted]: https://github.com/rubygems/release-gem

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,8 +59,9 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at [INSERT CONTACT
-METHOD]. All complaints will be reviewed and investigated promptly and fairly.
+privately reported to the community leaders responsible for enforcement as a
+[security vulnerability][security vulnerability]. All complaints will be
+reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.
@@ -124,5 +125,6 @@ For answers to common questions about this code of conduct, see the FAQ at
 <https://www.contributor-covenant.org/faq>. Translations are available at
 <https://www.contributor-covenant.org/translations>.
 
-[homepage]: https://www.contributor-covenant.org
 [Mozilla CoC]: https://github.com/mozilla/diversity
+[homepage]: https://www.contributor-covenant.org
+[security vulnerability]: https://github.com/halostatue/hoe-halostatue/security/advisories/new

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,5 +31,5 @@ Here's the most direct way to get your work merged into the project:
 - Create a pull request against halostatue/hoe-halostatue and describe what your
   change does and the why you think it should be merged.
 
-[quality commit messages]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 [hoe]: https://github.com/seattlerb/hoe
+[quality commit messages]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,20 +1,30 @@
 # Contributors
 
-- Austin Ziegler created Hoe::Halostatue.
+- Austin Ziegler ([@halostatue][@halostatue]) created Hoe::Halostatue.
 
 It would not be possible without Ryan Davis's [Hoe][hoe] and depends on the work
 of others in the Ruby community:
 
-- James Tucker (@raggi) for [`hoe-gemspec2`][hoe-gemspec2]
-- James Barnette (@jbarnette) for [`hoe-doofus`][hoe-doofus],
-  [`hoe-git2`][hoe-git2], and [`hoe-rubygems`][hoe-rubygems]
-- Mike Dalessio (@flavorjones) for [`hoe-markdown`][hoe-markdown]
-- Samuel Giddins (@segiddins) for providing the inspiration to make all of this
-  work better for trusted publishing for RubyGems.
+- James Tucker ([@raggi][@raggi]) for [`hoe-gemspec2`][hoe-gemspec2].
+- James Barnette ([@jbarnette][@jbarnette]) for [`hoe-doofus`][hoe-doofus],
+  [`hoe-git2`][hoe-git2], and [`hoe-rubygems`][hoe-rubygems].
+- Mike Dalessio ([@flavorjones][@flavorjones]) for
+  [`hoe-markdown`][hoe-markdown].
+- Samuel Giddins ([@segiddins][@segiddins]) for providing the inspiration to
+  make all of this work better for trusted publishing for RubyGems.
+- Jean Boussier ([@byroot][@byroot]) for creating and pointing me to
+  [RailsStrictWarnings][rsw].
 
-[hoe]: https://github.com/seattlerb/hoe
+[@byroot]: https://github.com/byroot
+[@flavorjones]: https://github.com/flavorjones
+[@halostatue]: https://github.com/halostatue
+[@jbarnette]: https://github.com/jbarnette
+[@raggi]: https://github.com/raggi
+[@segiddins]: https://github.com/segiddins
 [hoe-doofus]: https://github.com/jbarnette/hoe-doofus
 [hoe-gemspec2]: https://github.com/raggi/hoe-gemspec2
 [hoe-git2]: https://github.com/halostatue/hoe-git2
 [hoe-markdown]: https://github.com/flavorjones/hoe-markdown
 [hoe-rubygems]: https://github.com/jbarnette/hoe-rubygems
+[hoe]: https://github.com/seattlerb/hoe
+[rsw]: https://github.com/rails/rails/blob/66732971111a62e5940268e1daf7d413c72a234f/tools/strict_warnings.rb

--- a/README.md
+++ b/README.md
@@ -145,6 +145,35 @@ workflow. It will bypass certain protections offered by Hoe and Hoe::Halostatue:
 
 - The release checklist will be skipped.
 
+### Strict Warnings
+
+Warnings can be made strict (an exception will be thrown) for tests by adding
+the following to your test or spec helper file (`test/minitest_helper.rb` or
+`spec/rspec_helper.rb` or similar):
+
+```ruby
+require "hoe/halostatue/strict_warnings"
+
+# Optional but recommended to avoid getting warnings outside of your code.
+Hoe::Halostatue::StrictWarnings.project_root = File.expand_path("../", __dir__)
+
+# Optional regex patterns to suppress. Suppressed messages will not be printed
+# to standard error. The patterns provided will be converted to a single regex
+# on assignment.
+Hoe::Halostatue::StrictWarnings.suppressed = [
+  /circular require considered harmful/
+]
+
+# Optional regex patterns to allow. Allowed messages will be printed to
+# standard error, but will not raise an exception. The patterns provided will
+# be converted to a single regex on assignment.
+Hoe::Halostatue::StrictWarnings.allowed = [
+  /oval require considered harmful/
+]
+```
+
+This is based on [RailsStrictWarnings][rsw].
+
 ## Dependencies
 
 Hoe and Git 2.37 or later.
@@ -161,4 +190,5 @@ $ gem install hoe-halostatue
 [hoe-markdown]: https://github.com/flavorjones/hoe-markdown
 [hoe-rubygems]: https://github.com/jbarnette/hoe-rubygems
 [hoe]: https://github.com/seattlerb/hoe
+[rsw]: https://github.com/rails/rails/blob/66732971111a62e5940268e1daf7d413c72a234f/tools/strict_warnings.rb
 [tp]: https://guides.rubygems.org/trusted-publishing/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,15 +6,15 @@ Security reports are accepted only for the most recent minor release.
 
 ## Reporting a Vulnerability
 
-Alternatively, Send an email to [hoe-halostatue@halostatue.ca][email] with the
-text `hoe-halostatue` in the subject. Emails sent to this address should be
-encrypted using [age][age] with the following public key:
+Create a [draft security advisory][advisory]. Alternatively, send an email to
+[hoe-halostatue@halostatue.ca][email] with the text `hoe-halostatue` in the
+subject. Emails sent to this address should be encrypted using [age][age] with
+the following public key:
 
 ```
 age1fc6ngxmn02m62fej5cl30lrvwmxn4k3q2atqu53aatekmnqfwumqj4g93w
 ```
 
-[email]: mailto:hoe-halostatue@halostatue.ca
+[advisory]: https://github.com/halostatue/hoe-halostatue/security/advisories/new
 [age]: https://github.com/FiloSottile/age
-[CVE-2017-17405]: https://nvd.nist.gov/vuln/detail/CVE-2017-17405
-[openuri]: https://sakurity.com/blog/2015/02/28/openuri.html
+[email]: mailto:hoe-halostatue@halostatue.ca

--- a/hoe-halostatue.gemspec
+++ b/hoe-halostatue.gemspec
@@ -1,16 +1,16 @@
 # -*- encoding: utf-8 -*-
-# stub: hoe-halostatue 2.0.0 ruby lib
+# stub: hoe-halostatue 2.0.1 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "hoe-halostatue".freeze
-  s.version = "2.0.0".freeze
+  s.version = "2.0.1".freeze
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.metadata = { "bug_tracker_uri" => "https://github.com/halostatue/halostatue-data/issues", "changelog_uri" => "https://github.com/halostatue/halostatue-data/blob/main/CHANGELOG.md", "homepage_uri" => "https://github.com/halostatue/halostatue-data/", "rubygems_mfa_required" => "true", "source_code_uri" => "https://github.com/halostatue/halostatue-data/" } if s.respond_to? :metadata=
   s.require_paths = ["lib".freeze]
   s.authors = ["Austin Ziegler".freeze]
   s.date = "1980-01-02"
-  s.description = "Hoe::Halostatue is a Hoe meta-plugin that provides improved support for\nMarkdown README files, provides features from other plugins, and enables\nimproved support for trusted publishing.".freeze
+  s.description = "Hoe::Halostatue is a Hoe meta-plugin that provides improved support for Markdown README files, provides features from other plugins, and enables improved support for trusted publishing.".freeze
   s.email = ["halostatue@gmail.com".freeze]
   s.extra_rdoc_files = ["CHANGELOG.md".freeze, "CODE_OF_CONDUCT.md".freeze, "CONTRIBUTING.md".freeze, "CONTRIBUTORS.md".freeze, "LICENCE.md".freeze, "Manifest.txt".freeze, "README.md".freeze, "SECURITY.md".freeze]
   s.files = ["CHANGELOG.md".freeze, "CODE_OF_CONDUCT.md".freeze, "CONTRIBUTING.md".freeze, "CONTRIBUTORS.md".freeze, "LICENCE.md".freeze, "Manifest.txt".freeze, "README.md".freeze, "Rakefile".freeze, "SECURITY.md".freeze, "lib/hoe/halostatue.rb".freeze, "lib/hoe/halostatue/version.rb".freeze]

--- a/lib/hoe/halostatue.rb
+++ b/lib/hoe/halostatue.rb
@@ -95,6 +95,8 @@ module Hoe::Halostatue
     self.trusted_release = false
   end
 
+  LINKS = /\[(?<name>.+?)\](?:\(.+?\)|\[.+?\])/
+
   def define_halostatue_tasks # :nodoc:
     desc "Show a reminder for steps I frequently forget"
     task :checklist do
@@ -121,17 +123,12 @@ module Hoe::Halostatue
       end
     end
 
-    task :spec_clean_markdown_text do
-      spec.description =
-        spec.description.gsub(/\[([^\]]+)\]\([^)]+\)/, '\1')
-          .gsub(/\[([^\]]+)\]\[[^\]]+\]/, '\1')
-
-      spec.summary =
-        spec.summary.gsub(/\[([^\]]+)\]\([^)]+\)/, '\1')
-          .gsub(/\[([^\]]+)\]\[[^\]]+\]/, '\1')
+    task :spec_clean_markdown_links do
+      spec.description = spec.description.gsub(LINKS, '\k<name>').gsub(/\r?\n/, " ")
+      spec.summary = spec.summary.gsub(LINKS, '\k<name>').gsub(/\r?\n/, " ")
     end
 
-    task "#{spec.name}.gemspec" => :spec_clean_markdown_text
+    task "#{spec.name}.gemspec" => :spec_clean_markdown_links
 
     if trusted_release
       task :trusted_release do

--- a/lib/hoe/halostatue/strict_warnings.rb
+++ b/lib/hoe/halostatue/strict_warnings.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+$VERBOSE = true
+Warning[:deprecated] = true
+
+module Hoe::Halostatue::StrictWarnings # :nodoc:
+  class << self
+    attr_accessor :project_root
+    attr_reader :allowed
+    attr_reader :suppressed
+
+    def allowed=(patterns)
+      @allowed = Regexp.union(*Array(patterns))
+    end
+
+    def suppressed=(patterns)
+      @suppressed = Regex.union(*Array(patterns))
+    end
+  end
+
+  WarningError = Class.new(StandardError)
+
+  def warn(message, ...)
+    pattern = Hoe::Halostatue::StrictWarnings.suppressed
+    return if pattern&.match?(message)
+
+    super
+
+    return unless ENV["STRICT_WARNINGS"] || ENV["CI"]
+
+    project_root = Hoe::Halostatue::StrictWarnings.project_root
+    return if project_root && !message.include?(project_root)
+
+    pattern = Hoe::Halostatue::StrictWarnings.allowed
+    return if pattern&.match?(message)
+
+    raise WarningError.new(message)
+  end
+end
+
+Warning.singleton_class.prepend(Hoe::Halostatue::StrictWarnings)

--- a/lib/hoe/halostatue/version.rb
+++ b/lib/hoe/halostatue/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hoe::Halostatue
-  VERSION = "2.0.1"
+  VERSION = "2.1.0"
 end


### PR DESCRIPTION
- Add support for enabling "strict warnings" similar to [RailsStrictWarnings][rsw].

- Updated several governance documents.

- Improved summary and link description cleaning.

[rsw]: https://github.com/rails/rails/blob/66732971111a62e5940268e1daf7d413c72a234f/tools/strict_warnings.rb